### PR TITLE
Add prototype flag to React tutorial

### DIFF
--- a/tutorial/simple-todos/01-creating-app.md
+++ b/tutorial/simple-todos/01-creating-app.md
@@ -12,7 +12,7 @@ Install the latest official Meteor release [following the steps in our docs](htt
 The easiest way to setup Meteor with React is by using the command `meteor create` with the option `--react` and your project name (you can also omit the `--react` option since it is the default):
 
 ```
-meteor create simple-todos-react
+meteor create simple-todos-react --prototype
 ```
 
 Meteor will create all the necessary files for you. 


### PR DESCRIPTION
in 2.9, insecure will need to be added manually; for this tutorial not to be outdated, I will adjust its creation by passing the --prototype flag as shown in the [pr](https://github.com/meteor/meteor/pull/12220)