### PR TITLE
doc(methods): update wrong imports to update

### DIFF
--- a/tutorial/simple-todos/09-methods.md
+++ b/tutorial/simple-todos/09-methods.md
@@ -179,9 +179,8 @@ We would like to take a moment here to think, the folder where the collection fi
 
 This change is not required but it's recommended to keep our names consistent with reality.
 
-Remember to fix your imports, you have 4 imports to `TasksCollection` in the following files:
+Remember to fix your imports, you have 3 imports to `TasksCollection` in the following files:
 - `imports/api/tasksMethods.js`
-- `imports/ui/TaskForm.jsx`
 - `imports/ui/App.jsx`
 - `server/main.js`
 


### PR DESCRIPTION
Hello :)

These paths to updates are wrong.
To have a reference, follow the [step09](https://github.com/meteor/react-tutorial/blob/master/src/simple-todos/step09/imports/ui/TaskForm.jsx) file. It does not have any `TasksCollection` to update in this file.

The doc: https://react-tutorial.meteor.com/simple-todos/09-methods.html#9-4-api-and-db-folders
![image](https://github.com/meteor/react-tutorial/assets/70543018/2f4547b7-bf86-4303-943e-1a9eae295c1a)
